### PR TITLE
ci: allow running actions on renovate branches

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -2,7 +2,7 @@ name: Go
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "renovate/**" ]
   pull_request:
     branches: [ "main" ]
 


### PR DESCRIPTION
In order for Renovate to run checks on auto generated branches, this PR adds the required config changes.