### PR TITLE
feat: regenerate SQS interface through action

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -15,12 +15,7 @@
       "extends": "monorepo:aws-sdk-go-v2",
       "groupName": "aws-sdk-go-v2 monorepo",
       "excludePackageNames": ["github.com/aws/aws-sdk-go-v2/service/sqs"],
-      "matchUpdateTypes": [
-        "digest",
-        "patch",
-        "minor",
-        "major"
-      ]
+      "matchUpdateTypes": ["digest", "patch", "minor", "major"]
     },
     {
       "extends": [":automergeDisabled"],

--- a/.github/workflows/gen_sqs.yml
+++ b/.github/workflows/gen_sqs.yml
@@ -1,0 +1,30 @@
+name: Regenerate SQS
+
+on:
+  push:
+    branches: [ "renovate/**aws-sdk-go-v2-service-sqs*" ]
+    paths: [ "go.mod" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+    steps:
+    - uses: actions/checkout@v4
+
+    - name: Set up Go
+      uses: actions/setup-go@v5
+      with:
+        go-version: '1.22'
+
+    - name: Install Dependancies
+      run: make setup
+
+    - name: Generate SQS Interface
+      run: make generate_sqs
+
+    - name: Commit Change
+      uses: stefanzweifel/git-auto-commit-action@v5
+      with:
+        commit_message: "chore: regenerate sqs interface"

--- a/Makefile
+++ b/Makefile
@@ -20,7 +20,6 @@ generate_sqs:
 	@cd tmp_aws; git sparse-checkout set --no-cone service/sqs && git checkout
 	@ifacemaker -f "tmp_aws/service/sqs/*.go" -i "SQSClient" -p "sqsextendedclient" -s "Client" -o "sqs.go" -c "Generated from $$(cd tmp_aws; git tag -l 'service/sqs/v*' --sort -creatordate | head -n 1)" -D -y 'SQSClient is a wrapper interface for the [github.com/aws/aws-sdk-go-v2/service/sqs.Client].'
 	@sed -i '' 's/*/*sqs./gi' sqs.go
-	@sed -i '' 's|"context"|"context"\n\n\t"github.com/aws/aws-sdk-go-v2/service/sqs"|gi' sqs.go
 	@rm -rf tmp_aws
 	$(call log_done)
 


### PR DESCRIPTION
This PR adds in a new workflow to regenerate the SQS interface (`sqs.go`) whenever Renovate pushes commits to its matching branch. Ultimately, this should make the created PR with the new version include changes to both the `go.mod` file and the updated client.